### PR TITLE
feat: add test cases for "Remove from lis" task

### DIFF
--- a/test/remove-from-list.test.js
+++ b/test/remove-from-list.test.js
@@ -24,4 +24,16 @@ describe('Remove from list', () => {
     const expected = convertArrayToList([1, 2, 4, 5]);
     assert.deepEqual(removeKFromList(initial, 3), expected);
   });
+
+  it.optional('should return the list without values equal to k (with double k)', () => {
+    const initial = convertArrayToList([1, 2, 3, 3, 4, 5]);
+    const expected = convertArrayToList([1, 2, 4, 5]);
+    assert.deepEqual(removeKFromList(initial, 3), expected);
+  });
+
+  it.optional('should return the list without values equal to k (with k at the end)', () => {
+    const initial = convertArrayToList([1, 2, 3]);
+    const expected = convertArrayToList([1, 2]);
+    assert.deepEqual(removeKFromList(initial, 3), expected);
+  });
 });


### PR DESCRIPTION
Add more test cases for the "Remove from list" task in accordance to the issue [update tests for "Remove from list" task](https://github.com/AlreadyBored/basic-js-ds/issues/6)

- list with double `k` value:  initial [1, 2, 3, 3, 4, 5], expected [1, 2, 4, 5])
- list with `k` at the end: initial [1, 2, 3], expected [1, 2] )
